### PR TITLE
我對 `run_in_colab.ipynb` 進行了更新，以修復透過 GitHub Colab 徽章開啟時發生的 `TypeError:…

### DIFF
--- a/updated_notebook.ipynb
+++ b/updated_notebook.ipynb
@@ -14,12 +14,12 @@
     "  - `一般模式`: 以標準方式啟動服務。\n",
     "  - `除錯模式`: 啟動服務時將輸出更詳細的日誌，方便排查問題。"
    ],
-   "id": "a683dfa1e33a"
+   "id": "xG9pSjY3rL",
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
    "outputs": [],
    "source": [
     "# --- Python 模組導入 ---\n",
@@ -165,7 +165,8 @@
     "    settings_output\n",
     ")\n"
    ],
-   "id": "068718213004"
+   "id": "lBkIs8iFpE",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -175,12 +176,12 @@
     "點擊下方按鈕開始下載專案程式碼、安裝所需依賴，並啟動後端與前端服務。\n",
     "**注意**: 此步驟可能需要幾分鐘時間，特別是首次執行時。"
    ],
-   "id": "f1052007a08f"
+   "id": "pYqLzY7kIm",
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
    "outputs": [],
    "source": [
     "start_services_button = widgets.Button(\n",
@@ -280,7 +281,8 @@
     "start_services_button.on_click(on_start_services_clicked)\n",
     "display(start_services_button, services_output)\n"
    ],
-   "id": "443400973004"
+   "id": "iN7tJkS0oL",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -290,12 +292,12 @@
     "點擊下方按鈕以檢查後端和前端服務的狀態。如果服務均已就緒，將會顯示前端的訪問連結。\n",
     "**注意**: 健康檢查可能需要 1-2 分鐘，請耐心等待。"
    ],
-   "id": "c7a481b8076a"
+   "id": "rD3sVkE9qL",
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
    "outputs": [],
    "source": [
     "health_check_button = widgets.Button(\n",
@@ -466,12 +468,15 @@
     "health_check_button.on_click(on_health_check_clicked)\n",
     "display(health_check_button, health_check_output)\n"
    ],
-   "id": "8d2d11995521"
+   "id": "sK0lPqN2uY",
+   "metadata": {}
   }
  ],
  "metadata": {
   "colab": {
-   "provenance": []
+   "provenance": [],
+   "collapsed_sections": [],
+   "include_colab_link": true
   },
   "kernelspec": {
    "display_name": "Python 3",


### PR DESCRIPTION
… Cannot read properties of undefined (reading 'id')` 錯誤。

主要的變更包括：
1.  **調整了儲存格 ID 的格式**：我為筆記本中的所有儲存格重新生成了10位長度的隨機字母數字ID，使其更符合 Colab 原生ID的格式，取代了先前使用的純十六進制ID。
2.  **標準化了筆記本層級的 Metadata**：
    *   我在頂層 `metadata.colab` 中明確加入了 `provenance: []`，`collapsed_sections: []` 和 `include_colab_link: true`。這些是 Colab 環境中常見的元數據欄位，補全它們有助於提升兼容性。
3.  **標準化了儲存格層級的 Metadata**：我將所有儲存格的 `metadata` 欄位統一設定為空字典 `{}`，以避免因不必要的或不正確的元數據導致解析問題。

這些調整是基於我對 Colab `.ipynb` 檔案結構的進一步分析和常見實踐的推斷，旨在解決先前修復未能完全覆蓋的邊緣情況，特別是與外部連結（如徽章）載入相關的解析問題。